### PR TITLE
Add HTML example for embedding a Google Sheet

### DIFF
--- a/embed_spreadsheet.html
+++ b/embed_spreadsheet.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Google 스프레드시트 임베드 예제</title>
+    <style>
+        body { margin: 0; padding: 20px; font-family: Arial, sans-serif; }
+        iframe { width: 100%; height: 600px; border: none; }
+    </style>
+</head>
+<body>
+    <h1>스프레드시트 보기</h1>
+    <iframe src="https://docs.google.com/spreadsheets/d/15F-JVzuW-K-YnQ-xCYKYP_jkXF-xE3hsa2YtGALAOes/pubhtml?gid=1341001321&widget=true&headers=false"></iframe>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML page with an iframe that embeds a Google Spreadsheet
- update the iframe link to use the requested sheet ID

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68482febf67c8329bbdd50c41ffd0db2